### PR TITLE
Cancel subscription API endpoint

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -9,6 +9,15 @@ class Api::V1::SubscriptionsController < ApplicationController
     end
   end
 
+  def update
+    # binding.pry
+    if Subscription.exists?(params[:subscription_id])
+      current_sub = Subscription.find(params[:subscription_id])
+      current_sub.update(subscription_params)
+      render json: SubscriptionSerializer.new(current_sub), status: 200
+    end
+  end
+
   private
   def subscription_params
     params.permit(:title, :price, :frequency, :status, :tea_id, :customer_id)

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -10,11 +10,15 @@ class Api::V1::SubscriptionsController < ApplicationController
   end
 
   def update
+    if params[:status].nil?
+      render json: { error: 'Please provide status, no status found'}
     # binding.pry
-    if Subscription.exists?(params[:subscription_id])
-      current_sub = Subscription.find(params[:subscription_id])
-      current_sub.update(subscription_params)
-      render json: SubscriptionSerializer.new(current_sub), status: 200
+    else
+      if Subscription.exists?(params[:subscription_id])
+        current_sub = Subscription.find(params[:subscription_id])
+        current_sub.update(subscription_params)
+        render json: SubscriptionSerializer.new(current_sub), status: 200
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post "/customers/:id/subscriptions", to: "subscriptions#create"
+      patch "/customers/:customer_id/subscriptions/:subscription_id", to: "subscriptions#update"
     end
   end
 end

--- a/spec/requests/api/v1/subscriptions/cancel_subscription_endpoint_spec.rb
+++ b/spec/requests/api/v1/subscriptions/cancel_subscription_endpoint_spec.rb
@@ -29,4 +29,15 @@ RSpec.describe 'Cancel Subscription API' do
       expect(subscription[:attributes][:customer_id]).to eq(@tigo.id)
     end
   end
+
+  describe 'Sad Path' do
+    it 'Returns error if no status is provided' do
+      patch "/api/v1/customers/#{@tigo.id}/subscriptions/#{@tigo_sub.id}"
+
+      subscription = JSON.parse(response.body, symbolize_names: true)
+
+      expect(subscription).to have_key(:error)
+      expect(subscription[:error]).to eq("Please provide status, no status found")
+    end
+  end
 end

--- a/spec/requests/api/v1/subscriptions/cancel_subscription_endpoint_spec.rb
+++ b/spec/requests/api/v1/subscriptions/cancel_subscription_endpoint_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'Cancel Subscription API' do
+  before :each do
+    @tigo = Customer.create(first_name: 'tigo', last_name: 'sil', email: 'tigosil@gmail.com', address: '999 Denver Street')
+    @green = Tea.create(title: 'Green Tea', description: 'Great to jump start your day, caffinated', temp: '250F', brew_time: '3 Minutes')
+    @tigo_sub = Subscription.create(title: "Green Tea", price: 2.99, frequency: 1, customer_id: @tigo.id, tea_id: @green.id)
+    
+    @subscription_params = {
+      status: 'inactive'
+    }
+  end
+
+  describe 'Happy Path' do
+    it 'Cancels a subscription rendering it inactive' do
+      patch "/api/v1/customers/#{@tigo.id}/subscriptions/#{@tigo_sub.id}", params: @subscription_params
+
+      subscription = JSON.parse(response.body, symbolize_names: true)[:data]
+      # binding.pry
+      expect(response).to be_successful
+      expect(subscription[:type]).to eq('subscription')
+
+      expect(subscription[:attributes][:title]).to eq('Green Tea')
+      expect(subscription[:attributes][:price]).to eq(2.99)
+      expect(subscription[:attributes][:status]).to eq('inactive')
+      expect(subscription[:attributes][:frequency]).to eq('weekly')
+
+      expect(subscription[:attributes][:tea_id]).to eq(@green.id)
+      expect(subscription[:attributes][:customer_id]).to eq(@tigo.id)
+    end
+  end
+end


### PR DESCRIPTION
This PR..

- Closes #4 

This PR Introduces:

- Updating subscription to inactive
- Cancel sub route endpoint
- Cancel sub route happy and sad path specs